### PR TITLE
Support SolverBenchmarks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JSOBenchmarks"
 uuid = "9410e2bb-e8e7-4fa0-9768-685b196f59b5"
-authors = ["Dominique Orban <dominique.orban@gmail.com>"]
 version = "0.1.0"
+authors = ["Dominique Orban <dominique.orban@gmail.com>"]
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
@@ -11,6 +11,7 @@ Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -24,6 +25,7 @@ Git = "1.3"
 GitHub = "5.9"
 JLD2 = "0.4,0.5"
 JSON = "0.21"
+LibGit2 = "1.11.0"
 Pkg = "1.9"
 PkgBenchmark = "0.2"
 Plots = "1.39"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JSOBenchmarks"
 uuid = "9410e2bb-e8e7-4fa0-9768-685b196f59b5"
-version = "0.1.0"
 authors = ["Dominique Orban <dominique.orban@gmail.com>"]
+version = "0.1.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/JSOBenchmarks.jl
+++ b/src/JSOBenchmarks.jl
@@ -16,7 +16,9 @@ using Plots
 # JSO modules
 using SolverBenchmark
 
-export run_benchmarks
+include("solver_benchmarks.jl")
+
+export run_benchmarks, run_solver_benchmarks
 export profile_solvers_from_pkgbmark
 export create_gist_from_json_dict, create_gist_from_json_file
 export update_gist_from_json_dict, update_gist_from_json_file

--- a/src/JSOBenchmarks.jl
+++ b/src/JSOBenchmarks.jl
@@ -313,12 +313,24 @@ function write_simple_md_report(
   open(fname, "w") do f
     println(f, "Gist: $(gist_url)\n")
     println(f, "Full results stored as artifacts\n")
-    write_md_svgs(f, "Overview", gist_url, svgs)
-    write_md(f, "Judgement", judgement)
-    println(f, "<br>")
-    write_md(f, "this_commit", this_commit)
-    println(f, "<br>")
-    write_md(f, "Reference", reference)
+
+    if !isempty(svgs)
+      write_md_svgs(f, "Overview", gist_url, svgs)
+    end
+
+    if judgement !== nothing
+      write_md(f, "Judgement", judgement)
+      println(f, "<br>")
+    end
+
+    if this_commit !== nothing
+      write_md(f, "this_commit", this_commit)
+      println(f, "<br>")
+    end
+
+    if reference !== nothing
+      write_md(f, "Reference", reference)
+    end
   end
 end
 

--- a/src/JSOBenchmarks.jl
+++ b/src/JSOBenchmarks.jl
@@ -23,6 +23,7 @@ export run_benchmarks, run_solver_benchmarks
 export profile_solvers_from_pkgbmark
 export create_gist_from_json_dict, create_gist_from_json_file
 export update_gist_from_json_dict, update_gist_from_json_file
+export solver_benchmark_profile_values, solver_benchmark_table_values
 export write_md
 
 const git = Git.git()

--- a/src/JSOBenchmarks.jl
+++ b/src/JSOBenchmarks.jl
@@ -314,24 +314,12 @@ function write_simple_md_report(
   open(fname, "w") do f
     println(f, "Gist: $(gist_url)\n")
     println(f, "Full results stored as artifacts\n")
-
-    if !isempty(svgs)
-      write_md_svgs(f, "Overview", gist_url, svgs)
-    end
-
-    if judgement !== nothing
-      write_md(f, "Judgement", judgement)
-      println(f, "<br>")
-    end
-
-    if this_commit !== nothing
-      write_md(f, "this_commit", this_commit)
-      println(f, "<br>")
-    end
-
-    if reference !== nothing
-      write_md(f, "Reference", reference)
-    end
+    write_md_svgs(f, "Overview", gist_url, svgs)
+    write_md(f, "Judgement", judgement)
+    println(f, "<br>")
+    write_md(f, "this_commit", this_commit)
+    println(f, "<br>")
+    write_md(f, "Reference", reference)
   end
 end
 

--- a/src/JSOBenchmarks.jl
+++ b/src/JSOBenchmarks.jl
@@ -201,7 +201,7 @@ function run_benchmarks(
   )
 
   @info "finished"
-  return nothing
+  return update_gist ? gist_url : new_gist_url
 end
 
 # Utility functions

--- a/src/JSOBenchmarks.jl
+++ b/src/JSOBenchmarks.jl
@@ -10,6 +10,7 @@ using Git
 using GitHub
 using JLD2
 using JSON
+using LibGit2
 using PkgBenchmark
 using Plots
 

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -143,7 +143,7 @@ function _withcommit(script, repo, commit)
       exec_str =
         """
         using JSOBenchmarks
-        JSOBenchmarks._run_local($repr(script), "temp_result.json")
+        JSOBenchmarks._run_local($(repr(script)), "temp_result.json")
         """
       run(`$(Base.julia_cmd()) --project=$env_to_use --depwarn=no -e $exec_str`)
 

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -4,6 +4,7 @@ function run_solver_benchmarks(
   reference_branch::AbstractString = "main",
   gist_url::Union{AbstractString, Nothing} = nothing,
   script = "benchmarks.jl",
+  values = [(:elapsed_time, "CPU Time"), (:neval_obj, "# Objective Evals"), (:neval_grad, "# Gradient Evals")],
 )
 
   update_gist = gist_url !== nothing
@@ -36,9 +37,38 @@ function run_solver_benchmarks(
   # Run the benchmark script on the reference branch
   local reference
   if is_git
-    #reference = _withcommit(f, repo_name, reference_branch)
+    repo_dir = joinpath(bmark_dir, "..")
+    repo = LibGit2.GitRepo(repo_dir)
+    reference = _withcommit(joinpath(bmark_dir, script), repo, reference_branch)
   end
 
+  #TODO: save in a jld2 file: see run_benchmarks
+
+  # Plotting
+  if is_git
+    for key in keys(this_commit)
+      if haskey(reference, key)
+        @info "Plotting $key"
+        stats_subset = Dict(:this_commit => this_commit[key], :reference => reference[key])
+        solved(df) = (df.status .== :first_order)
+        for value in values 
+          @assert hasproperty(df, value[1]) "Expected the stats resulting from the benchmark script to have property $(value[1]), please check the values keyword argument."
+        end
+        costs = [df -> .!solved(df) * Inf + getproperty(df, value[1]) for value in values]
+        costnames = [value[2] for value in values]
+
+        p = profile_solvers(stats_subset, costs, costnames;xlabel = "", ylabel = "")
+        fname = "this_commit_vs_reference_$(key)"
+        savefig("$(fname).svg")
+      else
+        @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."
+      end
+    end
+
+  end
+
+
+  
 end
 
 
@@ -47,11 +77,13 @@ end
 # This code is based on https://github.com/JuliaCI/PkgBenchmark.jl/blob/master/src/util.jl
 function _withcommit(script, repo, commit)
   original_commit = _shastring(repo, "HEAD")
+  local result
   LibGit2.transact(repo) do r
     branch = try LibGit2.branch(r) catch err; nothing end
     try
       LibGit2.checkout!(r, _shastring(r, commit))
-      f()
+      result = Base.include(Main, script)
+      @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(this_commit)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solver function"
     catch err
         rethrow(err)
     finally
@@ -62,6 +94,7 @@ function _withcommit(script, repo, commit)
       end
     end
   end
+  return result
 end
 
 _shastring(r::LibGit2.GitRepo, targetname) = string(LibGit2.revparseid(r, targetname))

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -164,7 +164,7 @@ function _withcommit(script, repo, commit)
 end
 
 function _run_local(script, file_name)
-  include(script)
+  res = include(Main, script)
   open(file_name, "w") do io
     JSON.write(io, res)
   end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -110,8 +110,8 @@ function run_solver_benchmarks(
   is_git &&
     write_simple_md_report(
       "bmark_$(bmarkname).md",
-      this_commit,
-      reference,
+      nothing,
+      nothing,
       nothing,
       new_gist_url,
       svgs,

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -58,14 +58,14 @@ function run_solver_benchmarks(
         costnames = [value[2] for value in values]
 
         p = profile_solvers(stats_subset, costs, costnames;xlabel = "", ylabel = "")
-        fname = "this_commit_vs_reference_$(key)"
+        fname = "## This commit vs reference: $(key)\n\n"
         savefig("$(fname).svg")
         push!(svgs, "$(fname).svg")
         content = read("$(fname).svg", String)
         files_dict["$(fname).svg"] = Dict("content" => content)
-        println(this_commit[key])
         tables *= "\n" * fname * "\n"
         tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown))
+        tables *= "\n"
         tables *= sprint(io -> pretty_stats(io, reference[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown))
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -76,11 +76,11 @@ function run_solver_benchmarks(
         tables *= "### This commit\n\n\n"
         latex_tables *= "### This commit\n\n\n"
         tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_markdown))
-        latex_tables *= sprint(io -> pretty_latex_stats(io, this_commit[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_latex))
+        latex_tables *= sprint(io -> pretty_latex_stats(io, this_commit[key][!, stats_columns], hdr_override = Dict(table_values)))
         tables *= "\n\n### Reference\n\n\n"
         latex_tables *= "\n\n### Reference\n\n\n"
         tables *= sprint(io -> pretty_stats(io, reference[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_markdown))
-        latex_tables *= sprint(io -> pretty_latex_stats(io, reference[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_latex))
+        latex_tables *= sprint(io -> pretty_latex_stats(io, reference[key][!, stats_columns], hdr_override = Dict(table_values)))
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."
       end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -63,9 +63,10 @@ function run_solver_benchmarks(
         push!(svgs, "$(fname).svg")
         content = read("$(fname).svg", String)
         files_dict["$(fname).svg"] = Dict("content" => content)
-        tables *= "\n## This commit vs reference: $(key)\n\n\n"
+        tables *= "\n## This commit vs reference: $(key)\n\n"
+        tables *= "### This commit\n\n\n"
         tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown))
-        tables *= "\n"
+        tables *= "\n\n### Reference\n\n\n"
         tables *= sprint(io -> pretty_stats(io, reference[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown))
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -1,0 +1,13 @@
+function run_solver_benchmarks(
+  repo_name::AbstractString,
+  bmark_dir::AbstractString;
+  reference_branch::AbstractString = "main",
+  gist_url::Union{AbstractString, Nothing} = nothing,
+)
+
+  update_gist = gist_url !== nothing
+  is_git = isdir(joinpath(bmark_dir, "..", ".git"))
+  @info "" is_git update_gist
+
+  
+end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -118,7 +118,7 @@ function _withcommit(script, repo, commit)
   LibGit2.transact(repo) do r
     branch = try LibGit2.branch(r) catch err; nothing end
     try
-      LibGit2.checkout!(r, _sha(r, commit))
+      LibGit2.checkout!(r, _shastring(r, commit))
       result = Base.include(Main, script)
       @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(result)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solver function"
     catch err

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -58,7 +58,6 @@ function run_solver_benchmarks(
   stats_columns = [value[1] for value in table_values]
 
   tables = "# Solver Benchmarks Tables \n\n"
-  latex_tables = "# Solver Benchmarks Tables \n\n"
   if is_git
     for key in keys(this_commit)
       if haskey(reference, key)
@@ -73,17 +72,17 @@ function run_solver_benchmarks(
         files_dict["$(fname).svg"] = Dict("content" => content)
 
         @info "Creating tables for $key"
-        # TODO: make a function to avoid code repetition here
         tables *= "\n## This commit vs reference: $(key)\n\n"
-        latex_tables *= "\n## This commit vs reference: $(key)\n\n"
         tables *= "### This commit\n\n\n"
-        latex_tables *= "### This commit\n\n\n"
         tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_markdown))
-        latex_tables *= sprint(io -> pretty_latex_stats(io, this_commit[key][!, stats_columns], hdr_override = Dict(table_values)))
+        open("this_commit_$(key).tex", "w") do io
+          pretty_latex_stats(io, this_commit[key][!, stats_columns], hdr_override = Dict(table_values))
+        end
         tables *= "\n\n### Reference\n\n\n"
-        latex_tables *= "\n\n### Reference\n\n\n"
         tables *= sprint(io -> pretty_stats(io, reference[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_markdown))
-        latex_tables *= sprint(io -> pretty_latex_stats(io, reference[key][!, stats_columns], hdr_override = Dict(table_values)))
+        open("reference_$(key).tex", "w") do io
+          pretty_latex_stats(io, reference[key][!, stats_columns], hdr_override = Dict(table_values))
+        end
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."
       end
@@ -91,9 +90,6 @@ function run_solver_benchmarks(
   end
 
   files_dict["tables.md"] = Dict("content" => tables)
-  open("$(bmarkname)_solver_benchmarks_tables.txt", "w") do io
-    println(io, latex_tables)
-  end
 
   @info "creating or updating gist"
   # json description of gist

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -30,5 +30,39 @@ function run_solver_benchmarks(
   @info "" bmarkname
 
   # Run the benchmark script on this commit
-  this_commit = include(joinpath(bmark_dir, script))
+  this_commit = Base.include(Main, joinpath(bmark_dir, script))
+  @assert this_commit isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(this_commit)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solver function"
+
+  # Run the benchmark script on the reference branch
+  local reference
+  if is_git
+    #reference = _withcommit(f, repo_name, reference_branch)
+  end
+
 end
+
+
+# Runs a script at a commit on a repo and afterwards goes back
+# to the original commit / branch.
+# This code is based on https://github.com/JuliaCI/PkgBenchmark.jl/blob/master/src/util.jl
+function _withcommit(script, repo, commit)
+  original_commit = _shastring(repo, "HEAD")
+  LibGit2.transact(repo) do r
+    branch = try LibGit2.branch(r) catch err; nothing end
+    try
+      LibGit2.checkout!(r, _shastring(r, commit))
+      f()
+    catch err
+        rethrow(err)
+    finally
+      if branch !== nothing
+        LibGit2.branch!(r, branch)
+      else
+        LibGit2.checkout!(r, original_commit)
+      end
+    end
+  end
+end
+
+_shastring(r::LibGit2.GitRepo, targetname) = string(LibGit2.revparseid(r, targetname))
+_shastring(dir::AbstractString, targetname) = LibGit2.with(r -> _shastring(r, targetname), LibGit2.GitRepo(dir))

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -39,6 +39,8 @@ function run_solver_benchmarks(
   if is_git
     repo_dir = joinpath(bmark_dir, "..")
     repo = LibGit2.GitRepo(repo_dir)
+    println("repo_dir : $repo_dir")
+    println("bmark_dir : $bmark_dir")
     reference = _withcommit(joinpath(bmark_dir, script), repo, reference_branch)
   end
 

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -147,7 +147,7 @@ function _withcommit(script, repo, commit)
         """
       run(`$(Base.julia_cmd()) --project=$env_to_use --depwarn=no -e $exec_str`)
 
-      result = JSON.read(read("temp_result.json", String), Dict{Symbol, DataFrame})
+      result = load("temp.jld2")["result"]
 
       @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(result)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solvers function"
     catch err
@@ -164,10 +164,8 @@ function _withcommit(script, repo, commit)
 end
 
 function _run_local(script, file_name)
-  res = Base.include(Main, script)
-  open(file_name, "w") do io
-    JSON.write(io, res)
-  end
+  result = Base.include(Main, script)
+  @save "temp.jld2" result
 end
 
 function _shastring(r::LibGit2.GitRepo, targetname)

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -139,6 +139,7 @@ end
 
 function _shastring(r::LibGit2.GitRepo, targetname)
   branch = LibGit2.lookup_branch(r, targetname)
+  branch = branch === nothing ? LibGit2.lookup_branch(r, targetname, true) : branch # Search remote as well if not found locally.
   @assert branch !== nothing "Branch $(targetname) not found in repository."
   return string(LibGit2.GitHash(LibGit2.GitObject(r, LibGit2.name(branch))))
 end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -134,5 +134,10 @@ function _withcommit(script, repo, commit)
   return result
 end
 
-_shastring(r::LibGit2.GitRepo, targetname) = string(LibGit2.revparseid(r, targetname))
-_shastring(dir::AbstractString, targetname) = LibGit2.with(r -> _shastring(r, targetname), LibGit2.GitRepo(dir))
+function _shastring(r::LibGit2.GitRepo, targetname)
+  try
+    return string(LibGit2.revparseid(r, targetname))
+  catch
+    return string(LibGit2.revparseid(r, "origin/$targetname"))
+  end
+end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -1,3 +1,55 @@
+"""
+    run_solver_benchmarks(repo_name, bmark_dir; reference_branch="main", gist_url=nothing, script="benchmarks.jl")
+
+Run a benchmark script, based on the SolverBenchmarks.jl package, for a Julia repository.
+
+This function executes a benchmark script (`script`) in the specified benchmark directory (`bmark_dir`) for 
+the current state of the repository containing `repo_name`. 
+The output of the script should be a result of `BenchmarkSolver.bmark_solvers`. If the repository is a Git repository, the 
+benchmarks are run on the current commit and optionally compared to a reference branch (default `"main"`). 
+The results are saved as `.jld2` files, performance profile plots and summary tables are generated. 
+Optionally, results can be uploaded or updated in a GitHub Gist (`gist_url`).
+
+# Arguments
+
+- `repo_name::AbstractString`  
+  The name of the Julia package repository being benchmarked.
+
+- `bmark_dir::AbstractString`  
+  Path to the directory containing the benchmark scripts. This is usually a `benchmarks/` folder 
+  inside the repository.
+
+# Keyword Arguments
+
+- `reference_branch::AbstractString = "main"`  
+  The Git branch used as a reference for comparison in plots and tables.
+
+- `gist_url::Union{AbstractString, Nothing} = nothing`  
+  If provided, the function updates the existing Gist at this URL. Otherwise, a new Gist is created.
+
+- `script::AbstractString = "benchmarks.jl"`  
+  The Julia script in `bmark_dir` that runs the benchmark suite. Must return a `Dict{Symbol, DataFrame}` 
+  as produced by `BenchmarkSolver.bmark_solvers`.
+
+# Output
+
+Returns a `String` containing the URL of the Gist with benchmark results. If `gist_url` was provided, 
+the existing Gist is updated; otherwise, a new Gist URL is returned.
+
+# Plots and Tables values
+
+In order to compare specific outputs from the benchmark results, the `script` can override the functions
+    JSOBenchmarks.solver_benchmark_profile_values()
+    JSOBenchmarks.solver_benchmark_table_values()
+to specify which columns from the DataFrames should be used for the performance profiles and summary tables, respectively.
+Both should return an array of pairs, where the first element is a `Symbol` representing the column name in the DataFrame
+and the second element is a `String` representing the label to be used in the plots and tables.
+
+# Notes
+
+- This function is mostly expected to be called from a GitHub workflow.
+- Please refer to `SolverBenchmarks.bmark_solvers` for more information on how to write the benchmark script.
+"""
 function run_solver_benchmarks(
   repo_name::AbstractString,
   bmark_dir::AbstractString;

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -62,7 +62,7 @@ function run_solver_benchmarks(
         fname = "this_commit_vs_reference_$(key)"
         savefig("$(fname).svg")
         push!(svgs, "$(fname).svg")
-        content = read(fname, String)
+        content = read("$(fname).svg", String)
         files_dict[fname] = Dict("content" => content)
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -164,7 +164,7 @@ function _withcommit(script, repo, commit)
 end
 
 function _run_local(script, file_name)
-  res = include(Main, script)
+  res = Base.include(Main, script)
   open(file_name, "w") do io
     JSON.write(io, res)
   end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -69,9 +69,9 @@ function run_solver_benchmarks(
         @info "Creating tables for $key"
         tables *= "\n## This commit vs reference: $(key)\n\n"
         tables *= "### This commit\n\n\n"
-        tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = table_values, tf=tf_markdown))
+        tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_markdown))
         tables *= "\n\n### Reference\n\n\n"
-        tables *= sprint(io -> pretty_stats(io, reference[key][!, stats_columns], hdr_override = table_values, tf=tf_markdown))
+        tables *= sprint(io -> pretty_stats(io, reference[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_markdown))
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."
       end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -4,7 +4,8 @@ function run_solver_benchmarks(
   reference_branch::AbstractString = "main",
   gist_url::Union{AbstractString, Nothing} = nothing,
   script = "benchmarks.jl",
-  values = [(:elapsed_time, "CPU Time"), (:neval_obj, "# Objective Evals"), (:neval_grad, "# Gradient Evals")],
+  profile_values = [(:elapsed_time, "CPU Time"), (:neval_obj, "# Objective Evals"), (:neval_grad, "# Gradient Evals")],
+  table_values = [(:name, "Name"), (:objective, "f(x)"), (:elapsed_time, "Time")]
 )
 
   update_gist = gist_url !== nothing
@@ -45,24 +46,28 @@ function run_solver_benchmarks(
   # Plotting and tables
   files_dict = Dict{String, Any}()
   svgs = String[]
-  stats_columns = [:name, :objective, :elapsed_time]
-  hdr_override = Dict([:name => "Name", :objective => "f(x)", :elapsed_time => "Time"])
+
+  solved(df) = (df.status .== :first_order)
+  costs = [df -> .!solved(df) * Inf + getproperty(df, value[1]) for value in profile_values]
+  costnames = [value[2] for value in profile_values]
+
+  stats_columns = [value[1] for value in table_values]
+  hdr_override = [value[2] for value in table_values]
+
   tables = "# Solver Benchmarks Tables \n\n"
   if is_git
     for key in keys(this_commit)
       if haskey(reference, key)
         @info "Plotting $key"
         stats_subset = Dict(:this_commit => this_commit[key], :reference => reference[key])
-        solved(df) = (df.status .== :first_order)
-        costs = [df -> .!solved(df) * Inf + getproperty(df, value[1]) for value in values]
-        costnames = [value[2] for value in values]
-
-        p = profile_solvers(stats_subset, costs, costnames;xlabel = "", ylabel = "")
+        p = profile_solvers(stats_subset, costs, costnames, xlabel = "", ylabel = "")
         fname = "this_commit_vs_reference_$(key)"
         savefig("$(fname).svg")
         push!(svgs, "$(fname).svg")
         content = read("$(fname).svg", String)
         files_dict["$(fname).svg"] = Dict("content" => content)
+
+        @info "Creating tables for $key"
         tables *= "\n## This commit vs reference: $(key)\n\n"
         tables *= "### This commit\n\n\n"
         tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown))

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -150,7 +150,7 @@ function _withcommit(script, repo, commit; bmarkname = "")
       LibGit2.checkout!(r, _shastring(r, commit))
 
       env_to_use = dirname(Pkg.Types.Context().env.project_file) 
-      save_file_name = "$(bmarkname)_solver_benchmarks_$(commit)"
+      save_file_name = "$(bmarkname)_solver_benchmarks_reference"
       exec_str =
         """
         using JSOBenchmarks

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -34,13 +34,14 @@ function run_solver_benchmarks(
   # Run the benchmark script on this commit
   this_commit = Base.include(Main, joinpath(bmark_dir, script))
   @assert this_commit isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(this_commit)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solvers function"
+  @save "$(bmarkname)_solver_benchmarks_this_commit.jld2" this_commit
 
   # Run the benchmark script on the reference branch
   local reference
   if is_git
     repo_dir = joinpath(bmark_dir, "..")
     repo = LibGit2.GitRepo(repo_dir)
-    reference = _withcommit(joinpath(bmark_dir, script), repo, reference_branch)
+    reference = _withcommit(joinpath(bmark_dir, script), repo, reference_branch, bmarkname = bmarkname)
   end
 
   # Plotting and tables
@@ -54,6 +55,7 @@ function run_solver_benchmarks(
   stats_columns = [value[1] for value in table_values]
 
   tables = "# Solver Benchmarks Tables \n\n"
+  latex_tables = "# Solver Benchmarks Tables \n\n"
   if is_git
     for key in keys(this_commit)
       if haskey(reference, key)
@@ -67,11 +69,17 @@ function run_solver_benchmarks(
         files_dict["$(fname).svg"] = Dict("content" => content)
 
         @info "Creating tables for $key"
+        # TODO: make a function to avoid code repetition here
         tables *= "\n## This commit vs reference: $(key)\n\n"
+        latex_tables *= "\n## This commit vs reference: $(key)\n\n"
         tables *= "### This commit\n\n\n"
+        latex_tables *= "### This commit\n\n\n"
         tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_markdown))
+        latex_tables *= sprint(io -> pretty_latex_stats(io, this_commit[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_latex))
         tables *= "\n\n### Reference\n\n\n"
+        latex_tables *= "\n\n### Reference\n\n\n"
         tables *= sprint(io -> pretty_stats(io, reference[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_markdown))
+        latex_tables *= sprint(io -> pretty_latex_stats(io, reference[key][!, stats_columns], hdr_override = Dict(table_values), tf=tf_latex))
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."
       end
@@ -79,6 +87,7 @@ function run_solver_benchmarks(
   end
 
   files_dict["tables.md"] = Dict("content" => tables)
+  @save "$(bmarkname)_solver_benchmarks_tables.txt" latex_tables
 
   @info "creating or updating gist"
   # json description of gist
@@ -131,7 +140,7 @@ end
 # Runs a script at a commit on a repo and afterwards goes back
 # to the original commit / branch.
 # This code is based on https://github.com/JuliaCI/PkgBenchmark.jl/blob/master/src/util.jl
-function _withcommit(script, repo, commit)
+function _withcommit(script, repo, commit; bmarkname = "")
   original_commit = string(LibGit2.GitHash(LibGit2.GitObject(repo, "HEAD")))
   local result
   LibGit2.transact(repo) do r
@@ -140,14 +149,15 @@ function _withcommit(script, repo, commit)
       LibGit2.checkout!(r, _shastring(r, commit))
 
       env_to_use = dirname(Pkg.Types.Context().env.project_file) 
+      save_file_name = "$(bmarkname)_solver_benchmarks_$(commit)"
       exec_str =
         """
         using JSOBenchmarks
-        JSOBenchmarks._run_local($(repr(script)), "temp_result.json")
+        JSOBenchmarks._run_local($(repr(script)), $(save_file_name))
         """
       run(`$(Base.julia_cmd()) --project=$env_to_use --depwarn=no -e $exec_str`)
 
-      result = load("temp.jld2")["result"]
+      result = load("$(save_file_name).jld2")["result"]
 
       @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(result)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solvers function"
     catch err
@@ -163,9 +173,9 @@ function _withcommit(script, repo, commit)
   return result
 end
 
-function _run_local(script, file_name)
+function _run_local(script, save_file_name)
   result = Base.include(Main, script)
-  @save "temp.jld2" result
+  @save "$(save_file_name).jld2" result
 end
 
 function _shastring(r::LibGit2.GitRepo, targetname)

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -113,7 +113,7 @@ end
 # to the original commit / branch.
 # This code is based on https://github.com/JuliaCI/PkgBenchmark.jl/blob/master/src/util.jl
 function _withcommit(script, repo, commit)
-  original_commit = LibGit2.GitHash(LibGit2.GitObject(repo, "HEAD"))
+  original_commit = string(LibGit2.GitHash(LibGit2.GitObject(repo, "HEAD")))
   local result
   LibGit2.transact(repo) do r
     branch = try LibGit2.branch(r) catch err; nothing end
@@ -134,8 +134,8 @@ function _withcommit(script, repo, commit)
   return result
 end
 
-function _sha(r::LibGit2.GitRepo, targetname)
+function _shastring(r::LibGit2.GitRepo, targetname)
   branch = LibGit2.lookup_branch(r, targetname)
   @assert branch !== nothing "Branch $(targetname) not found in repository."
-  return LibGit2.GitHash(LibGit2.GitObject(r, LibGit2.name(branch)))
+  return string(LibGit2.GitHash(LibGit2.GitObject(r, LibGit2.name(branch))))
 end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -74,10 +74,6 @@ function run_solver_benchmarks(
     end
   end
 
-  readme = "# $(repo_name) Solver Benchmarks\n\n"
-  readme *= "Comparison between current commit and $(reference_branch).\n\n"
-
-  files_dict["README.md"] = Dict("content" => readme)
   files_dict["TABLES.md"] = Dict("content" => tables)
 
   @info "creating or updating gist"

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -108,7 +108,7 @@ function run_solver_benchmarks(
     )
   
   @info "finished"
-  return nothing
+  return update_gist ? gist_url : new_gist_url
 end
 
 

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -58,12 +58,12 @@ function run_solver_benchmarks(
         costnames = [value[2] for value in values]
 
         p = profile_solvers(stats_subset, costs, costnames;xlabel = "", ylabel = "")
-        fname = "## This commit vs reference: $(key)\n\n"
+        fname = "this_commit_vs_reference_$(key)"
         savefig("$(fname).svg")
         push!(svgs, "$(fname).svg")
         content = read("$(fname).svg", String)
         files_dict["$(fname).svg"] = Dict("content" => content)
-        tables *= "\n" * fname * "\n"
+        tables *= "\n## This commit vs reference: $(key)\n\n\n"
         tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown))
         tables *= "\n"
         tables *= sprint(io -> pretty_stats(io, reference[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown))

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -116,16 +116,17 @@ function run_solver_benchmarks(
     new_gist_url = string(new_gist.html_url)
   end
 
-  @info "preparing simple Markdown report"
-  is_git &&
-    write_simple_md_report(
-      "bmark_$(bmarkname).md",
-      nothing,
-      nothing,
-      nothing,
-      update_gist ? gist_url : new_gist_url,
-      svgs,
-    )
+  # TODO: Update the markdown report instead!
+  # @info "preparing simple Markdown report"
+  # is_git &&
+  #   write_simple_md_report(
+  #     "bmark_$(bmarkname).md",
+  #     nothing,
+  #     nothing,
+  #     nothing,
+  #     update_gist ? gist_url : new_gist_url,
+  #     svgs,
+  #   )
   
   @info "finished"
   return update_gist ? gist_url : new_gist_url

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -64,6 +64,7 @@ function run_solver_benchmarks(
         p = profile_solvers(stats_subset, costs, costnames, xlabel = "", ylabel = "")
         fname = "this_commit_vs_reference_$(key)"
         savefig("$(fname).svg")
+        savefig("profiles_$(fname).pdf")
         push!(svgs, "$(fname).svg")
         content = read("$(fname).svg", String)
         files_dict["$(fname).svg"] = Dict("content" => content)

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -154,7 +154,7 @@ function _withcommit(script, repo, commit; bmarkname = "")
       exec_str =
         """
         using JSOBenchmarks
-        JSOBenchmarks._run_local($(repr(script)), $(save_file_name))
+        JSOBenchmarks._run_local($(repr(script)), "$(save_file_name)")
         """
       run(`$(Base.julia_cmd()) --project=$env_to_use --depwarn=no -e $exec_str`)
 

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -87,14 +87,6 @@ function run_solver_benchmarks(
     JSON.print(f, json_dict)
   end
 
-  local new_gist_url
-  if update_gist
-    update_gist_from_json_dict(gist_id, json_dict)
-  else
-    new_gist = create_gist_from_json_dict(json_dict)
-    new_gist_url = string(new_gist.html_url)
-  end
-
   readme = "# $(repo_name) Solver Benchmarks\n\n"
   readme *= "Comparison between current commit and $(reference_branch).\n\n"
 
@@ -105,6 +97,28 @@ function run_solver_benchmarks(
   end
 
   files_dict["README.md"] = Dict("content" => readme)
+
+  local new_gist_url
+  if update_gist
+    update_gist_from_json_dict(gist_id, json_dict)
+  else
+    new_gist = create_gist_from_json_dict(json_dict)
+    new_gist_url = string(new_gist.html_url)
+  end
+
+  @info "preparing simple Markdown report"
+  is_git &&
+    write_simple_md_report(
+      "bmark_$(bmarkname).md",
+      this_commit,
+      reference,
+      nothing,
+      new_gist_url,
+      svgs,
+    )
+  
+  @info "finished"
+  return nothing
 end
 
 

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -42,9 +42,12 @@ function run_solver_benchmarks(
     reference = _withcommit(joinpath(bmark_dir, script), repo, reference_branch)
   end
 
-  # Plotting
+  # Plotting and tables
   files_dict = Dict{String, Any}()
   svgs = String[]
+  stats_columns = [:name, :f, :t]
+  hdr_override = Dict([:name => "Name", :f => "f(x)", :t => "Time"])
+  tables = "# Solver Benchmarks Tables \n\n"
   if is_git
     for key in keys(this_commit)
       if haskey(reference, key)
@@ -55,6 +58,7 @@ function run_solver_benchmarks(
         costnames = [value[2] for value in values]
 
         p = profile_solvers(stats_subset, costs, costnames;xlabel = "", ylabel = "")
+        tables *= pretty_stats(String, stats_subset[!, stats_columns], hdr_override = hdr_override, tf=tf_markdown)
         fname = "this_commit_vs_reference_$(key)"
         savefig("$(fname).svg")
         push!(svgs, "$(fname).svg")
@@ -70,6 +74,7 @@ function run_solver_benchmarks(
   readme *= "Comparison between current commit and $(reference_branch).\n\n"
 
   files_dict["README.md"] = Dict("content" => readme)
+  files_dict["TABLES.md"] = Dict("content" => tables)
 
   @info "creating or updating gist"
   # json description of gist

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -140,6 +140,8 @@ end
 function _shastring(r::LibGit2.GitRepo, targetname)
   branch = LibGit2.lookup_branch(r, targetname)
   branch = branch === nothing ? LibGit2.lookup_branch(r, targetname, true) : branch # Search remote as well if not found locally.
+  branch = branch === nothing ? LibGit2.lookup_branch(r, "origin/$(targetname)") : branch
+  branch = branch === nothing ? LibGit2.lookup_branch(r, "origin/$(targetname)", true) : branch # Search remote as well if not found locally.
   @assert branch !== nothing "Branch $(targetname) not found in repository."
   return string(LibGit2.GitHash(LibGit2.GitObject(r, LibGit2.name(branch))))
 end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -63,7 +63,7 @@ function run_solver_benchmarks(
         savefig("$(fname).svg")
         push!(svgs, "$(fname).svg")
         content = read("$(fname).svg", String)
-        files_dict[fname] = Dict("content" => content)
+        files_dict["$(fname).svg"] = Dict("content" => content)
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."
       end
@@ -89,12 +89,6 @@ function run_solver_benchmarks(
 
   readme = "# $(repo_name) Solver Benchmarks\n\n"
   readme *= "Comparison between current commit and $(reference_branch).\n\n"
-
-  for svg in svgs
-    title = replace(svg, ".svg" => "")
-    readme *= "## $(title)\n\n"
-    readme *= "![]($(svg))\n\n"
-  end
 
   files_dict["README.md"] = Dict("content" => readme)
 

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -88,7 +88,9 @@ function run_solver_benchmarks(
   end
 
   files_dict["tables.md"] = Dict("content" => tables)
-  @save "$(bmarkname)_solver_benchmarks_tables.txt" latex_tables
+  open("$(bmarkname)_solver_benchmarks_tables.txt", "w") do io
+    println(io, latex_tables)
+  end
 
   @info "creating or updating gist"
   # json description of gist

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -116,17 +116,13 @@ function run_solver_benchmarks(
     new_gist_url = string(new_gist.html_url)
   end
 
-  # TODO: Update the markdown report instead!
-  # @info "preparing simple Markdown report"
-  # is_git &&
-  #   write_simple_md_report(
-  #     "bmark_$(bmarkname).md",
-  #     nothing,
-  #     nothing,
-  #     nothing,
-  #     update_gist ? gist_url : new_gist_url,
-  #     svgs,
-  #   )
+  # Update markdown report
+  if is_git
+    fname = "bmark_$(bmarkname).md"
+    open(fname, "w") do f
+      write_md_svgs(f, "SolverBenchmark Profiles", gist_url, svgs)
+    end
+  end
   
   @info "finished"
   return update_gist ? gist_url : new_gist_url

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -45,8 +45,8 @@ function run_solver_benchmarks(
   # Plotting and tables
   local profile_values, table_values
 
-  profile_values = Main.solver_benchmark_profile_values()
-  table_values = Main.solver_benchmark_table_values()
+  profile_values = Base.invokelatest(solver_benchmark_profile_values)
+  table_values = Base.invokelatest(solver_benchmark_table_values)
 
   files_dict = Dict{String, Any}()
   svgs = String[]

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -32,7 +32,7 @@ function run_solver_benchmarks(
 
   # Run the benchmark script on this commit
   this_commit = Base.include(Main, joinpath(bmark_dir, script))
-  @assert this_commit isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(this_commit)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solver function"
+  @assert this_commit isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(this_commit)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solvers function"
 
   # Run the benchmark script on the reference branch
   local reference
@@ -125,7 +125,7 @@ function _withcommit(script, repo, commit)
     try
       LibGit2.checkout!(r, _shastring(r, commit))
       result = Base.include(Main, script)
-      @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(result)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solver function"
+      @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(result)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solvers function"
     catch err
         rethrow(err)
     finally

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -4,8 +4,6 @@ function run_solver_benchmarks(
   reference_branch::AbstractString = "main",
   gist_url::Union{AbstractString, Nothing} = nothing,
   script = "benchmarks.jl",
-  profile_values = solver_benchmark_profile_values(),
-  table_values = solver_benchmark_table_values()
 )
 
   update_gist = gist_url !== nothing
@@ -45,6 +43,11 @@ function run_solver_benchmarks(
   end
 
   # Plotting and tables
+  local profile_values, table_values
+
+  profile_values = Main.solver_benchmark_profile_values()
+  table_values = Main.solver_benchmark_table_values()
+
   files_dict = Dict{String, Any}()
   svgs = String[]
 

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -55,7 +55,7 @@ function run_solver_benchmarks(
         @info "Plotting $key"
         stats_subset = Dict(:this_commit => this_commit[key], :reference => reference[key])
         solved(df) = (df.status .== :first_order)
-        costs = [stats_subset -> .!solved(stats_subset) * Inf + getproperty(stats_subset, value[1]) for value in values]
+        costs = [df -> .!solved(df) * Inf + getproperty(df, value[1]) for value in values]
         costnames = [value[2] for value in values]
 
         p = profile_solvers(stats_subset, costs, costnames;xlabel = "", ylabel = "")

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -120,7 +120,7 @@ function _withcommit(script, repo, commit)
     try
       LibGit2.checkout!(r, _shastring(r, commit))
       result = Base.include(Main, script)
-      @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(this_commit)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solver function"
+      @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(result)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solver function"
     catch err
         rethrow(err)
     finally

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -45,6 +45,8 @@ function run_solver_benchmarks(
   #TODO: save in a jld2 file: see run_benchmarks
 
   # Plotting
+  files_dict = Dict{String, Any}()
+  svgs = String[]
   if is_git
     for key in keys(this_commit)
       if haskey(reference, key)
@@ -60,15 +62,50 @@ function run_solver_benchmarks(
         p = profile_solvers(stats_subset, costs, costnames;xlabel = "", ylabel = "")
         fname = "this_commit_vs_reference_$(key)"
         savefig("$(fname).svg")
+        push!(svgs, "$(fname).svg")
+        content = read(fname, String)
+        files_dict[fname] = Dict("content" => content)
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."
       end
     end
-
   end
 
+  @info "creating or updating gist"
+  # json description of gist
+  json_dict = Dict{String, Any}(
+    "description" => "$(repo_name) repository benchmark",
+    "public" => true,
+    "files" => files_dict,
+  )
 
-  
+  if update_gist
+    json_dict["gist_id"] = gist_id
+  end
+
+  gist_json = "$(bmarkname).json"
+  open(gist_json, "w") do f
+    JSON.print(f, json_dict)
+  end
+
+  local new_gist_url
+  if update_gist
+    update_gist_from_json_dict(gist_id, json_dict)
+  else
+    new_gist = create_gist_from_json_dict(json_dict)
+    new_gist_url = string(new_gist.html_url)
+  end
+
+  readme = "# $(repo_name) Solver Benchmarks\n\n"
+  readme *= "Comparison between current commit and $(reference_branch).\n\n"
+
+  for svg in svgs
+    title = replace(svg, ".svg" => "")
+    readme *= "## $(title)\n\n"
+    readme *= "![]($(svg))\n\n"
+  end
+
+  files_dict["README.md"] = Dict("content" => readme)
 end
 
 

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -4,8 +4,8 @@ function run_solver_benchmarks(
   reference_branch::AbstractString = "main",
   gist_url::Union{AbstractString, Nothing} = nothing,
   script = "benchmarks.jl",
-  profile_values = [(:elapsed_time, "CPU Time"), (:neval_obj, "# Objective Evals"), (:neval_grad, "# Gradient Evals")],
-  table_values = [(:name, "Name"), (:objective, "f(x)"), (:elapsed_time, "Time")]
+  profile_values = solver_benchmark_profile_values(),
+  table_values = solver_benchmark_table_values()
 )
 
   update_gist = gist_url !== nothing
@@ -121,6 +121,13 @@ function run_solver_benchmarks(
   return update_gist ? gist_url : new_gist_url
 end
 
+function solver_benchmark_profile_values()
+  return [(:elapsed_time, "CPU Time"), (:neval_obj, "# Objective Evals"), (:neval_grad, "# Gradient Evals")]
+end
+
+function solver_benchmark_table_values()
+  return [(:name, "Name"), (:objective, "f(x)"), (:elapsed_time, "Time")]
+end
 
 # Runs a script at a commit on a repo and afterwards goes back
 # to the original commit / branch.

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -58,12 +58,15 @@ function run_solver_benchmarks(
         costnames = [value[2] for value in values]
 
         p = profile_solvers(stats_subset, costs, costnames;xlabel = "", ylabel = "")
-        tables *= pretty_stats(String, stats_subset[!, stats_columns], hdr_override = hdr_override, tf=tf_markdown)
         fname = "this_commit_vs_reference_$(key)"
         savefig("$(fname).svg")
         push!(svgs, "$(fname).svg")
         content = read("$(fname).svg", String)
         files_dict["$(fname).svg"] = Dict("content" => content)
+
+        tables *= "\n" * fname * "\n"
+        tables *= pretty_stats(String, this_commit[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown)
+        tables *= pretty_stats(String, reference[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown)
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."
       end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -171,7 +171,7 @@ function run_solver_benchmarks(
   # Update markdown report
   if is_git
     fname = "bmark_$(bmarkname).md"
-    open(fname, "w") do f
+    open(fname, "a") do f
       write_md_svgs(f, "SolverBenchmark Profiles", gist_url, svgs)
     end
   end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -39,8 +39,6 @@ function run_solver_benchmarks(
   if is_git
     repo_dir = joinpath(bmark_dir, "..")
     repo = LibGit2.GitRepo(repo_dir)
-    println("repo_dir : $repo_dir")
-    println("bmark_dir : $bmark_dir")
     reference = _withcommit(joinpath(bmark_dir, script), repo, reference_branch)
   end
 
@@ -120,7 +118,6 @@ end
 # to the original commit / branch.
 # This code is based on https://github.com/JuliaCI/PkgBenchmark.jl/blob/master/src/util.jl
 function _withcommit(script, repo, commit)
-  println(repo)
   original_commit = string(LibGit2.GitHash(LibGit2.GitObject(repo, "HEAD")))
   local result
   LibGit2.transact(repo) do r

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -78,7 +78,7 @@ function run_solver_benchmarks(
     end
   end
 
-  files_dict["TABLES.md"] = Dict("content" => tables)
+  files_dict["tables.md"] = Dict("content" => tables)
 
   @info "creating or updating gist"
   # json description of gist
@@ -138,6 +138,8 @@ function _withcommit(script, repo, commit)
     branch = try LibGit2.branch(r) catch err; nothing end
     try
       LibGit2.checkout!(r, _shastring(r, commit))
+      # Recompile package
+      Pkg.precompile()
       result = Base.include(Main, script)
       @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(result)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solvers function"
     catch err

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -40,9 +40,6 @@ function run_solver_benchmarks(
   if is_git
     repo_dir = joinpath(bmark_dir, "..")
     repo = LibGit2.GitRepo(repo_dir)
-    println(bmark_dir)
-    println(script)
-    println(joinpath(bmark_dir, script))
     reference = _withcommit(joinpath(bmark_dir, script), repo, reference_branch)
   end
 
@@ -145,9 +142,12 @@ function _withcommit(script, repo, commit)
       env_to_use = dirname(Pkg.Types.Context().env.project_file) 
       exec_str =
         """
-        include($(repr(script)))
+        using JSOBenchmarks
+        JSOBenchmarks._run_local($repr(script), "temp_result.json")
         """
       run(`$(Base.julia_cmd()) --project=$env_to_use --depwarn=no -e $exec_str`)
+
+      result = JSON.read(read("temp_result.json", String), Dict{Symbol, DataFrame})
 
       @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(result)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solvers function"
     catch err
@@ -161,6 +161,13 @@ function _withcommit(script, repo, commit)
     end
   end
   return result
+end
+
+function _run_local(script, file_name)
+  include(script)
+  open(file_name, "w") do io
+    JSON.write(io, res)
+  end
 end
 
 function _shastring(r::LibGit2.GitRepo, targetname)

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -52,7 +52,6 @@ function run_solver_benchmarks(
   costnames = [value[2] for value in profile_values]
 
   stats_columns = [value[1] for value in table_values]
-  hdr_override = [value[2] for value in table_values]
 
   tables = "# Solver Benchmarks Tables \n\n"
   if is_git
@@ -70,9 +69,9 @@ function run_solver_benchmarks(
         @info "Creating tables for $key"
         tables *= "\n## This commit vs reference: $(key)\n\n"
         tables *= "### This commit\n\n\n"
-        tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown))
+        tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = table_values, tf=tf_markdown))
         tables *= "\n\n### Reference\n\n\n"
-        tables *= sprint(io -> pretty_stats(io, reference[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown))
+        tables *= sprint(io -> pretty_stats(io, reference[key][!, stats_columns], hdr_override = table_values, tf=tf_markdown))
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."
       end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -45,8 +45,8 @@ function run_solver_benchmarks(
   # Plotting and tables
   files_dict = Dict{String, Any}()
   svgs = String[]
-  stats_columns = [:name, :f, :t]
-  hdr_override = Dict([:name => "Name", :f => "f(x)", :t => "Time"])
+  stats_columns = [:name, :objective, :elapsed_time]
+  hdr_override = Dict([:name => "Name", :objective => "f(x)", :elapsed_time => "Time"])
   tables = "# Solver Benchmarks Tables \n\n"
   if is_git
     for key in keys(this_commit)
@@ -63,10 +63,10 @@ function run_solver_benchmarks(
         push!(svgs, "$(fname).svg")
         content = read("$(fname).svg", String)
         files_dict["$(fname).svg"] = Dict("content" => content)
-
+        println(this_commit[key])
         tables *= "\n" * fname * "\n"
-        tables *= pretty_stats(String, this_commit[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown)
-        tables *= pretty_stats(String, reference[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown)
+        tables *= sprint(io -> pretty_stats(io, this_commit[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown))
+        tables *= sprint(io -> pretty_stats(io, reference[key][!, stats_columns], hdr_override = hdr_override, tf=tf_markdown))
       else
         @warn "$(reference_branch) branch benchmarks do not run the solver $key. Please update the benchmark solver list in a separate PR and rebase."
       end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -40,6 +40,9 @@ function run_solver_benchmarks(
   if is_git
     repo_dir = joinpath(bmark_dir, "..")
     repo = LibGit2.GitRepo(repo_dir)
+    println(bmark_dir)
+    println(script)
+    println(joinpath(bmark_dir, script))
     reference = _withcommit(joinpath(bmark_dir, script), repo, reference_branch)
   end
 
@@ -138,9 +141,14 @@ function _withcommit(script, repo, commit)
     branch = try LibGit2.branch(r) catch err; nothing end
     try
       LibGit2.checkout!(r, _shastring(r, commit))
-      # Recompile package
-      Pkg.precompile()
-      result = Base.include(Main, script)
+
+      env_to_use = dirname(Pkg.Types.Context().env.project_file) 
+      exec_str =
+        """
+        include($(repr(script)))
+        """
+      run(`$(Base.julia_cmd()) --project=$env_to_use --depwarn=no -e $exec_str`)
+
       @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(result)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solvers function"
     catch err
         rethrow(err)

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -42,8 +42,6 @@ function run_solver_benchmarks(
     reference = _withcommit(joinpath(bmark_dir, script), repo, reference_branch)
   end
 
-  #TODO: save in a jld2 file: see run_benchmarks
-
   # Plotting
   files_dict = Dict{String, Any}()
   svgs = String[]
@@ -105,7 +103,7 @@ function run_solver_benchmarks(
       nothing,
       nothing,
       nothing,
-      new_gist_url,
+      update_gist ? gist_url : new_gist_url,
       svgs,
     )
   

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -3,11 +3,32 @@ function run_solver_benchmarks(
   bmark_dir::AbstractString;
   reference_branch::AbstractString = "main",
   gist_url::Union{AbstractString, Nothing} = nothing,
+  script = "benchmarks.jl",
 )
 
   update_gist = gist_url !== nothing
   is_git = isdir(joinpath(bmark_dir, "..", ".git"))
   @info "" is_git update_gist
 
-  
+  local gist_id
+  if update_gist
+    gist_id = split(gist_url, "/")[end]
+    @info "" gist_id
+  end
+
+  # if we are running these benchmarks from the git repository
+  # we want to develop the package instead of using the release
+  if is_git
+    Pkg.develop(PackageSpec(path = joinpath(bmark_dir, "..")))
+  else
+    Pkg.activate(bmark_dir)
+  end
+  Pkg.instantiate()
+
+  # name the benchmark after the repo or the sha of HEAD
+  bmarkname = is_git ? readchomp(`$git rev-parse HEAD`) : lowercase(repo_name)
+  @info "" bmarkname
+
+  # Run the benchmark script on this commit
+  this_commit = include(joinpath(bmark_dir, script))
 end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -66,6 +66,11 @@ function run_solver_benchmarks(
     end
   end
 
+  readme = "# $(repo_name) Solver Benchmarks\n\n"
+  readme *= "Comparison between current commit and $(reference_branch).\n\n"
+
+  files_dict["README.md"] = Dict("content" => readme)
+
   @info "creating or updating gist"
   # json description of gist
   json_dict = Dict{String, Any}(
@@ -82,11 +87,6 @@ function run_solver_benchmarks(
   open(gist_json, "w") do f
     JSON.print(f, json_dict)
   end
-
-  readme = "# $(repo_name) Solver Benchmarks\n\n"
-  readme *= "Comparison between current commit and $(reference_branch).\n\n"
-
-  files_dict["README.md"] = Dict("content" => readme)
 
   local new_gist_url
   if update_gist

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -135,9 +135,7 @@ function _withcommit(script, repo, commit)
 end
 
 function _shastring(r::LibGit2.GitRepo, targetname)
-  try
-    return string(LibGit2.revparseid(r, targetname))
-  catch
-    return string(LibGit2.revparseid(r, "origin/$targetname"))
-  end
+  branch = LibGit2.lookup_branch(r, targetname)
+  @assert branch !== nothing "Branch $(targetname) not found in repository."
+  return LibGit2.GitHash(LibGit2.GitObject(r, LibGit2.name(branch)))
 end

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -113,12 +113,12 @@ end
 # to the original commit / branch.
 # This code is based on https://github.com/JuliaCI/PkgBenchmark.jl/blob/master/src/util.jl
 function _withcommit(script, repo, commit)
-  original_commit = _shastring(repo, "HEAD")
+  original_commit = LibGit2.GitHash(LibGit2.GitObject(repo, "HEAD"))
   local result
   LibGit2.transact(repo) do r
     branch = try LibGit2.branch(r) catch err; nothing end
     try
-      LibGit2.checkout!(r, _shastring(r, commit))
+      LibGit2.checkout!(r, _sha(r, commit))
       result = Base.include(Main, script)
       @assert result isa Dict{Symbol, DataFrame} "Expected the benchmark script to return a Dict{Symbol, DataFrame}, but got $(typeof(result)). Make sure your benchmark script returns a dict resulting from BenchmarkSolver.bmark_solver function"
     catch err
@@ -134,7 +134,7 @@ function _withcommit(script, repo, commit)
   return result
 end
 
-function _shastring(r::LibGit2.GitRepo, targetname)
+function _sha(r::LibGit2.GitRepo, targetname)
   branch = LibGit2.lookup_branch(r, targetname)
   @assert branch !== nothing "Branch $(targetname) not found in repository."
   return LibGit2.GitHash(LibGit2.GitObject(r, LibGit2.name(branch)))

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -113,6 +113,7 @@ end
 # to the original commit / branch.
 # This code is based on https://github.com/JuliaCI/PkgBenchmark.jl/blob/master/src/util.jl
 function _withcommit(script, repo, commit)
+  println(repo)
   original_commit = string(LibGit2.GitHash(LibGit2.GitObject(repo, "HEAD")))
   local result
   LibGit2.transact(repo) do r

--- a/src/solver_benchmarks.jl
+++ b/src/solver_benchmarks.jl
@@ -55,10 +55,7 @@ function run_solver_benchmarks(
         @info "Plotting $key"
         stats_subset = Dict(:this_commit => this_commit[key], :reference => reference[key])
         solved(df) = (df.status .== :first_order)
-        for value in values 
-          @assert hasproperty(df, value[1]) "Expected the stats resulting from the benchmark script to have property $(value[1]), please check the values keyword argument."
-        end
-        costs = [df -> .!solved(df) * Inf + getproperty(df, value[1]) for value in values]
+        costs = [stats_subset -> .!solved(stats_subset) * Inf + getproperty(stats_subset, value[1]) for value in values]
         costnames = [value[2] for value in values]
 
         p = profile_solvers(stats_subset, costs, costnames;xlabel = "", ylabel = "")


### PR DESCRIPTION
Hi @tmigot, @dpo.

I added a function `run_solver_benchmarks` that allows to make a run with, for example, `SolverBenchmarks`.

## How does it work ?

Instead of being limited to the benchmark suits from `PkgBenchmark.jl`, this function executes a specified `script` from the repository being benchmarked on the current branch and on a specified `target_branch`.

This benchmark script can do whatever the user likes but should currently return a `Dict` like those returned from `bmark_solvers`.
The function then proceeds to construct performance profiles.

## Example use:
In `RegularizedOptimization.jl` i wrote a simple benchmark script as 
```
using RegularizedProblems, RegularizedOptimization, SolverBenchmark

bpdn_l0, _ = setup_bpdn_l0()
bpdn_l1, _ = setup_bpdn_l1()
bpdn_B0, _ = setup_bpdn_B0()

problem_list = [
  bpdn_l0,
  bpdn_l1,
  bpdn_B0,
]

solvers = Dict(
  :R2_precise => 
    reg_nlp -> R2(
      reg_nlp,
      verbose = 0,
      atol = 1e-6,
      rtol = 1e-6,
    ),
  :R2_imprecise => 
    reg_nlp -> R2(
      reg_nlp,
      verbose = 0,
      atol = 1e-3,
      rtol = 1e-3,
    )
)

stats = bmark_solvers(solvers, problem_list)
```
We also added a workflow that runs on PRs:
```
name: JSOBenchmarks
on:
  pull_request:
    types: [labeled, opened, synchronize, reopened]
  workflow_call:

jobs:
  bmark:
    name: Julia ${{ matrix.version }} - macOS - ${{ matrix.arch }} - ${{ github.event_name }}
    if: github.event_name == 'workflow_call' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run benchmarks'))
    # FIXME: should run on hosted runner
    runs-on: macOS-latest
    strategy:
      fail-fast: false
      matrix:
        version:
          - 1
        arch:
          - aarch64
    steps:
      - uses: actions/checkout@v6
        with:
          fetch-depth: 0
      - uses: julia-actions/setup-julia@v2
        with:
          version: ${{ matrix.version }}
          arch: ${{ matrix.arch }}
      - uses: julia-actions/cache@v2
      - uses: julia-actions/julia-buildpkg@v1
        # FIXME: register JSOBenchmarks
      - name: Installing non-registered dependencies
        run: |
          using Pkg
          pkg1 = PackageSpec(url = "https://github.com/MaxenceGollier/JSOBenchmarks.jl.git", rev = "solver_benchmarks")
          pkg2 = PackageSpec(url = "https://github.com/MaxenceGollier/SolverBenchmark.jl.git", rev = "switch-getters")
          pkg_list = [pkg1, pkg2]
          Pkg.add(pkg_list)
        shell: julia --project=benchmark --color=yes {0}
      - name: Install benchmark dependencies
        run: julia --project=benchmark -e 'using Pkg; Pkg.instantiate()'
      - name: Sanitize project name
        id: sanitize
        run: echo "REPONAME=${{ github.event.repository.name }}" | sed -e 's/\.jl$//' >> $GITHUB_OUTPUT
      - name: Run benchmarks
        run: julia --project=benchmark -e 'using JSOBenchmarks; run_solver_benchmarks("${{ steps.sanitize.outputs.REPONAME }}", "benchmark", reference_branch = "${{ github.event.pull_request.base.ref }}")'
        env:
          GITHUB_AUTH: ${{ secrets.GIST_TOKEN }}
      - name: Build comment
        id: build-comment
        uses: actions/github-script@v6
        with:
          github-token: ${{ github.token }}
          result-encoding: string
          script: |
            const fs = require('fs');
            return fs.readFileSync("${{ github.workspace }}/bmark_${{ github.sha }}.md", "utf8").toString();
      - name: Comment in PR
        uses: thollander/actions-comment-pull-request@v2
        with:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          message: ${{ steps.build-comment.outputs.result }}
      - name: Upload artifacts
        uses: actions/upload-artifact@v7
        with:
          name: jso-benchmarks
          path: |
            profiles_this_commit_vs_reference_*.svg
            *_vs_reference_*.jld2
            bmark_*.md
            reference.md
            judgement_*.md
```
I opened a PR where i add a bad modification to R2: https://github.com/JuliaSmoothOptimizers/RegularizedOptimization.jl/pull/309.
This gave the following gist:
https://gist.github.com/dpo/bfe8576c5f8e93940a57007513aebb0f


This is mostly a proof of concept and I am open to your suggestions on what we could add to the function to make it more flexible!

Thank you.