### PR TITLE
Use grouped bar plots for PkgBenchmark stats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SolverBenchmark = "581a75fa-a23a-52d0-a590-d6201de2218a"
+StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 
 [compat]
 BenchmarkTools = "1.3"
@@ -28,6 +29,7 @@ Pkg = "1.9"
 PkgBenchmark = "0.2"
 Plots = "1.39"
 SolverBenchmark = "0.5,0.6"
+StatsPlots = "0.15"
 julia = "^1.6"
 
 [extras]

--- a/src/JSOBenchmarks.jl
+++ b/src/JSOBenchmarks.jl
@@ -12,6 +12,7 @@ using JLD2
 using JSON
 using PkgBenchmark
 using Plots
+using StatsPlots
 
 # JSO modules
 using SolverBenchmark
@@ -113,12 +114,13 @@ function run_benchmarks(
         property == :name && continue
         commit_values = this_commit_k[!, property]
         reference_values = reference_k[!, property]
-        plot(
+        groupedbar(
           names,
           [commit_values, reference_values],
           title = string(property),
           label = ["commit" "reference"],
-          linewidth = 2,
+          bar_width = 0.7,
+          bar_position = :dodge,
           xticks = (1:length(names), names),
           xrotation = 45,
           tickfontsize = 4,

--- a/src/JSOBenchmarks.jl
+++ b/src/JSOBenchmarks.jl
@@ -121,7 +121,6 @@ function run_benchmarks(
           label = ["commit" "reference"],
           bar_width = 0.7,
           bar_position = :dodge,
-          xticks = (1:length(names), names),
           xrotation = 45,
           tickfontsize = 4,
         )

--- a/src/JSOBenchmarks.jl
+++ b/src/JSOBenchmarks.jl
@@ -114,12 +114,9 @@ function run_benchmarks(
         property == :name && continue
         commit_values = this_commit_k[!, property]
         reference_values = reference_k[!, property]
-        println("names", names)
-        println("commit_values", commit_values)
-        println("reference_values", reference_values)
         groupedbar(
           names,
-          [commit_values, reference_values],
+          [commit_values reference_values],
           title = string(property),
           label = ["commit" "reference"],
           bar_width = 0.7,

--- a/src/JSOBenchmarks.jl
+++ b/src/JSOBenchmarks.jl
@@ -114,6 +114,9 @@ function run_benchmarks(
         property == :name && continue
         commit_values = this_commit_k[!, property]
         reference_values = reference_k[!, property]
+        println("names", names)
+        println("commit_values", commit_values)
+        println("reference_values", reference_values)
         groupedbar(
           names,
           [commit_values, reference_values],


### PR DESCRIPTION
A bar plot should be easier to read than
a line plot.